### PR TITLE
feat(TabField): add tooltip to TabField in dialog

### DIFF
--- a/src/dialog/Dialog/Dialog.tsx
+++ b/src/dialog/Dialog/Dialog.tsx
@@ -198,7 +198,7 @@ export type TabbedField<FieldT, TabData = any, K extends string = string> = {
     type: K;
     fields: Array<DialogField<FieldT>>;
     size?: string;
-    title?: string;
+    title?: React.ReactNode | string;
     getTitle?: (data: TabData) => string;
     isRemovable?: (position: number) => boolean;
     renderControls?: (
@@ -311,7 +311,7 @@ interface OperateTabInfo {
     name: string;
     multiple?: boolean;
     index: number;
-    title: string;
+    title: React.ReactNode | string;
     isRemovable: (position: number) => boolean;
     renderControls?: TabbedField<any>['renderControls'];
     visibilityCondition?: TabbedField<any>['visibilityCondition'];

--- a/src/dialog/TabField/TabField.tsx
+++ b/src/dialog/TabField/TabField.tsx
@@ -29,7 +29,7 @@ export interface TabFieldProps {
 export interface TabItem {
     id: string;
     name: string;
-    title: string;
+    title: React.ReactNode | string;
     multiple?: boolean;
     removable?: boolean;
     error?: string | object;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

Added the titleTooltip property to display hover tooltips on dialog tabs. The tab title is conditionally wrapped in a Tooltip component, providing context while keeping the API simple without extra configurations.

## Summary by Sourcery

Add optional tooltip support for dialog tab titles and propagate the tooltip configuration through dialog tab definitions into TabField rendering.

New Features:
- Allow dialog tabs to specify an optional titleTooltip that shows a hover tooltip for the tab title in TabField.

Enhancements:
- Update TabField to conditionally wrap tab titles in a Tooltip component while preserving existing error indicator behavior.
- Extend dialog tab typing and tab processing logic to carry titleTooltip metadata from field configuration to rendered tabs.

Documentation:
- Show usage of titleTooltip for tabs in dialog Storybook examples.